### PR TITLE
Fix Typescript Imports

### DIFF
--- a/src/scripts/balancerPool.ts
+++ b/src/scripts/balancerPool.ts
@@ -1,6 +1,7 @@
 import { Signer } from "ethers";
 import hre from "hardhat";
-import { BFactory, BPool__factory } from "types";
+import { BFactory } from "types";
+import { BPool__factory } from "../types";
 
 export async function deployBalancerPool(
   bFactoryContract: BFactory,

--- a/src/scripts/elf.ts
+++ b/src/scripts/elf.ts
@@ -1,13 +1,7 @@
 import { Signer } from "ethers";
 import hre from "hardhat";
-import {
-  AYVault,
-  Elf,
-  Elf__factory,
-  ElfFactory,
-  ERC20,
-  YVaultAssetProxy,
-} from "types";
+import { AYVault, Elf, ElfFactory, ERC20, YVaultAssetProxy } from "types";
+import { Elf__factory } from "../types";
 
 export async function deployElf<T extends ERC20>(
   elfFactoryContract: ElfFactory,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,3 @@
-
 {
   "compilerOptions": {
     "target": "esnext",
@@ -18,7 +17,7 @@
       "contracts/*": ["./src/contracts/*"],
     },
   },
-  "include": ["./src/**/*"],
+  "include": ["./src/**/*", "./hardhat.config.ts"],
   "exclude": ["./frontend/**/*"],
-  "files": ["./hardhat.config.ts"]
+  "files": ["./src/**/*", "./hardhat.config.ts"]
 }


### PR DESCRIPTION
Although VSCode can now figure out the aliased paths, `npx hardhat compile` still can't seem to figure it out.  Reverting to using relative imports until I figure this out.