### PR TITLE
token address fmt fix

### DIFF
--- a/addresses/frontend-mainnet.json
+++ b/addresses/frontend-mainnet.json
@@ -6,8 +6,8 @@
         "userProxyContractAddress": "0xEe4e158c03A10CBc8242350d74510779A364581C",
         "weightedPoolFactoryAddress": "0x8E9aa87E45e92bad84D5F8DD1bff34Fb92637dE9",
         "stecrvAddress": "0x06325440D014e39736583c165C2963BA99fAf14E",
-        "lusd3crv-fAddress": "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca",
-        "crvtricryptoAddress": "0xca3d75ac011bf5ad07a98d02f18225f9bd9a6bdf",
+        "lusd3crv-fAddress": "0xEd279fDD11cA84bEef15AF5D39BB4d4bEE23F0cA",
+        "crvtricryptoAddress": "0xcA3d75aC011BF5aD07a98d02f18225F9bD9A6BDF",
         "daiAddress": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
     },
     "chainId": 1,

--- a/addresses/mainnet.json
+++ b/addresses/mainnet.json
@@ -1,11 +1,11 @@
 {
 	"tokens": {
-		"usdc": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+		"usdc": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
 		"weth": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-		"dai": "0x6b175474e89094c44da98b954eedeac495271d0f",
-		"lusd3crv-f": "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca",
-		"crvtricrypto": "0xca3d75ac011bf5ad07a98d02f18225f9bd9a6bdf",
-		"stecrv": "0x06325440d014e39736583c165c2963ba99faf14e"
+		"dai": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+		"lusd3crv-f": "0xEd279fDD11cA84bEef15AF5D39BB4d4bEE23F0cA",
+		"crvtricrypto": "0xcA3d75aC011BF5aD07a98d02f18225F9bD9A6BDF",
+		"stecrv": "0x06325440D014e39736583c165C2963BA99fAf14E"
 	},
 	"wrappedPositions": {
 		"yearn": {

--- a/changelog/releases/mainnet/v1.0.2:1/addresses.json
+++ b/changelog/releases/mainnet/v1.0.2:1/addresses.json
@@ -1,11 +1,11 @@
 {
 	"tokens": {
-		"usdc": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+		"usdc": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
 		"weth": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-		"dai": "0x6b175474e89094c44da98b954eedeac495271d0f",
-		"lusd3crv-f": "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca",
-		"crvtricrypto": "0xca3d75ac011bf5ad07a98d02f18225f9bd9a6bdf",
-		"stecrv": "0x06325440d014e39736583c165c2963ba99faf14e"
+		"dai": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+		"lusd3crv-f": "0xEd279fDD11cA84bEef15AF5D39BB4d4bEE23F0cA",
+		"crvtricrypto": "0xcA3d75aC011BF5aD07a98d02f18225F9bD9A6BDF",
+		"stecrv": "0x06325440D014e39736583c165C2963BA99fAf14E"
 	},
 	"wrappedPositions": {
 		"yearn": {


### PR DESCRIPTION
The "tokens" section of the mainnet.json file had improper casing which caused issues for the frontend team when using the fontend-mainnet.json.  Simple fix is to fix the casing in the source json and rerun post process step.

> Note: might be a good idea to eventually add a step that does a checksum verification on the frontend json file to ensure that there is no fmt issue
