### PR TITLE
post-processing-mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm run fundYtPool -- --network mainnet
 To generate json file for the frontend to process:
 
 ```bash
-npm run processAddresses -- --network mainnet
+sh scripts/postProcess.sh mainnet
 ```
 
 When prompted for the version, enter something like:

--- a/scripts/postProcess.sh
+++ b/scripts/postProcess.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ $1 = "mainnet" ]; then
+    WRITE_CHANGELOG=1 npm run processAddresses -- --network mainnet
+    npm run processAddresses -- --network goerli
+elif [ $1 = "goerli" ]; then
+    WRITE_CHANGELOG=1 npm run processAddresses -- --network goerli
+    npm run processAddresses -- --network mainnet
+fi

--- a/scripts/processAddresses.ts
+++ b/scripts/processAddresses.ts
@@ -75,10 +75,12 @@ async function main() {
     console.log(frontendJson);
     fs.writeFileSync('addresses/frontend-'+network+'.addresses.json', frontendJson,'utf8');
 
-    // get release version
-    const releaseVersion = readline.question("Release Version (e.g. vX.X.X:X): ");
-    fs.mkdirSync("changelog/releases/"+network+"/"+releaseVersion, { recursive: true })
-    fs.copyFileSync("addresses/"+network+".json","changelog/releases/"+network+"/"+releaseVersion+"/addresses.json")
+    if(process.env["WRITE_CHANGELOG"]=="1"){
+        // get release version
+        const releaseVersion = readline.question("Release Version (e.g. vX.X.X:X): ");
+        fs.mkdirSync("changelog/releases/"+network+"/"+releaseVersion, { recursive: true })
+        fs.copyFileSync("addresses/"+network+".json","changelog/releases/"+network+"/"+releaseVersion+"/addresses.json")
+    }
 }
 
 main()


### PR DESCRIPTION
create post-process.sh script to ensure that frontend json files for both networks are always updated if a new asset is created.  this is needed to ensure that the frontend schema check passes