### PR TITLE
Add validations to deployment scripts

### DIFF
--- a/addresses/mainnet.json
+++ b/addresses/mainnet.json
@@ -487,6 +487,7 @@
     }
   },
   "weightedPoolFactory": "0x8E9aa87E45e92bad84D5F8DD1bff34Fb92637dE9",
+  "deploymentValidator": "0xc68e2BAb13a7A2344bb81badBeA626012C62C510",
   "wrappedCoveredPrincipalToken": {
     "dai": "0x761298d1F5749e6523279547821A7DfdB5736B5D",
     "usdc": "0x810eeD88CfC3a32CB7A19d597CD6895C90dE0Aae"

--- a/scripts/deployAMMPools.ts
+++ b/scripts/deployAMMPools.ts
@@ -18,6 +18,7 @@ import hre from "hardhat";
 // Edit to import the correct version
 import goerliJson from "../addresses/goerli.json";
 import mainnetJson from "../addresses/mainnet.json";
+import { DeploymentValidator, DeploymentValidator__factory } from "typechain";
 
 export async function deployWeightedPool(
   signer: Signer,
@@ -68,6 +69,7 @@ export async function deployConvergentPool(
   tParam: number,
   network: string,
   pauser: string,
+  deploymentValidator: DeploymentValidator,
   options?: {
     swapFee?: string;
   }
@@ -107,6 +109,10 @@ export async function deployConvergentPool(
     poolAddress,
     signer
   );
+
+  // validate pool address
+  console.log("Registering pool address with deployment validator")
+  deploymentValidator.validatePoolAddress(poolAddress);
 
   const vault = await convergentPoolFactory.getVault();
   const feeGov = await convergentPoolFactory.percentFeeGov();
@@ -173,6 +179,11 @@ async function deployWithAddresses(addresses: any, network: string) {
   const weightedPoolFactory = weightedPoolFactoryFactory.attach(
     addresses.weightedPoolFactory
   );
+
+  // Get the deployed address validator
+  const deploymentValidatorAddress = addresses.deploymentValidator;
+  const deploymentValidatorFactory = new DeploymentValidator__factory(signer);
+  const deploymentValidator = deploymentValidatorFactory.attach(deploymentValidatorAddress);
 
   // Load the tranche
   const trancheAddress = readline.question("tranche address: ");
@@ -263,6 +274,7 @@ async function deployWithAddresses(addresses: any, network: string) {
       t,
       network,
       pauser,
+      deploymentValidator,
       {
         swapFee: swapFeeString,
       }

--- a/scripts/deployer/deployer.ts
+++ b/scripts/deployer/deployer.ts
@@ -8,6 +8,7 @@ import { YVaultAssetProxy__factory } from "../../typechain/factories/YVaultAsset
 import { DateString__factory } from "../../typechain/factories/DateString__factory";
 import { UserProxy__factory } from "../../typechain/factories/UserProxy__factory";
 import * as readline from "readline-sync";
+import { DeploymentValidator } from "typechain";
 
 const provider = ethers.providers.getDefaultProvider("goerli");
 
@@ -117,7 +118,8 @@ export async function deployFactories() {
 }
 
 export async function deployWrappedPosition(
-  deploymentData: WrappedPositionData
+  deploymentData: WrappedPositionData,
+  deploymentValidator: DeploymentValidator
 ) {
   const [signer] = await ethers.getSigners();
 
@@ -138,6 +140,11 @@ export async function deployWrappedPosition(
     }
   );
   await wrappedPosition.deployed();
+
+  // validate wp address
+  console.log("Registering wp address with deployment validator")
+  deploymentValidator.validatePoolAddress(wrappedPosition.address);
+
   await hre.run("verify:verify", {
     network: "mainnet",
     address: wrappedPosition.address,


### PR DESCRIPTION
Adds validations to deployment scripts for deployWrappedPosition and deployConvergentPool to register WP and Pool addresses on deployment in the DeploymentValidator contract added in this PR: https://github.com/element-fi/elf-contracts/pull/247