### PR TITLE
Add set-zap-approvals script shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "processAddressesGoerli": "npx hardhat run --network goerli scripts/processAddresses.ts",
     "deployWcptFactory": "npx hardhat run scripts/deployWrappedCoverTokenFactory.ts",
     "createWcpt": "npx hardhat run scripts/deployWrappedCoverPrincipalToken.ts",
-    "set-zap-approvals": "npx hardhat run scripts/runSetZapSwapCurveApprovals.ts --no-compile"
+    "setZapApprovals": "npx hardhat run scripts/runSetZapSwapCurveApprovals.ts --no-compile"
   },
   "devDependencies": {
     "@ethersproject/transactions": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "processAddresses": "npx hardhat run scripts/processAddresses.ts",
     "processAddressesGoerli": "npx hardhat run --network goerli scripts/processAddresses.ts",
     "deployWcptFactory": "npx hardhat run scripts/deployWrappedCoverTokenFactory.ts",
-    "createWcpt": "npx hardhat run scripts/deployWrappedCoverPrincipalToken.ts"
+    "createWcpt": "npx hardhat run scripts/deployWrappedCoverPrincipalToken.ts",
+    "set-zap-approvals": "npx hardhat run scripts/runSetZapSwapCurveApprovals.ts --no-compile"
   },
   "devDependencies": {
     "@ethersproject/transactions": "^5.5.0",


### PR DESCRIPTION
Creates a slightly handier shortcut for the script, just run `npm run setZapApprovals -- --network <network>`